### PR TITLE
Remove deprecated title/description from publish:gitlab step

### DIFF
--- a/scaffolder-templates/quarkus-web-template/template.yaml
+++ b/scaffolder-templates/quarkus-web-template/template.yaml
@@ -181,8 +181,6 @@ spec:
       action: publish:gitlab
       input:
         repoUrl: "{{ '${{ parameters.repo.host }}' }}?owner={{ '${{ parameters.repo.owner }}' }}&repo={{ '${{parameters.component_id}}' }}-gitops"
-        title: gitops resources for {{ '${{ parameters.component_id }}' }}
-        description: gitops resources for {{ '${{ parameters.component_id }}' }}
         sourcePath: ./tenant-gitops
         repoVisibility: public
 


### PR DESCRIPTION
RHDH 1.10 no longer accepts these properties in the publish:gitlab action

## What does this PR do / why we need it

## Which issue(s) does this PR fix

Fixes #?

## How to test changes / Special notes to the reviewer
